### PR TITLE
add tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ notes.txt
 .rspec
 vendor
 *.pyc
+tags


### PR DESCRIPTION
this is intended to avoid the repo becoming dirty
when the help file doc/tags is autogenerated. I'm using
Pathogen and using wordpress.vim as a git submodule,
when I run :Helptags it generates doc/tags. As a note, I've noticed some
of the other vim plugin repos I have as submodules are using a .gitignore
file in this way.
